### PR TITLE
Airlines: add CRUD service and API; search returns all matches

### DIFF
--- a/src/conf/enums.py
+++ b/src/conf/enums.py
@@ -1,3 +1,3 @@
 # Allowed values used by validation and UI dropdowns
-CLIENT_TYPES = {"business", "leisure", "vip", "corporate"}
-AIRLINE_TYPES = {"national", "regional", "low_cost", "charter"}
+CLIENT_TYPES = {"Business", "Leisure", "VIP", "Corporate"}
+AIRLINE_TYPES = {"National", "Regional", "Low Cost", "Charter"}

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os
 from pathlib import Path
-from flask import Flask, jsonify
+from flask import Flask, app, jsonify
 from src.conf import settings
 from src.conf.errors import DomainError, to_http
 from src.record.common.storage import ensure_dir
@@ -31,8 +31,13 @@ def create_app() -> Flask:
     def health():
         return jsonify({"status": "ok", "version": app.config["API_VERSION"]})
 
-    # Blueprints
+    #======== Blueprints ========
+    # Clients
     from src.record.clients.api import bp as clients_bp
     app.register_blueprint(clients_bp, url_prefix=f"/api/{app.config['API_VERSION']}/clients")
+
+    # Airlines
+    from src.record.airlines.api import bp as airlines_bp
+    app.register_blueprint(airlines_bp, url_prefix=f"/api/{app.config['API_VERSION']}/airlines")
 
     return app

--- a/src/record/airlines/api.py
+++ b/src/record/airlines/api.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request, url_for
+
+from src.conf.errors import InvalidInput
+from src.record.airlines.service import (
+    create_airline,
+    get_airline,
+    update_airline,
+    delete_airline,
+    list_airlines,
+    search_airlines,
+    DEFAULT_LIMIT,
+)
+
+bp = Blueprint("airlines", __name__)
+
+@bp.get("/")
+def list_or_search():
+    """
+    GET /api/v1/airlines
+    - If search params present (q or type): return ALL matches.
+    - Otherwise: paginated list (limit/offset) like Clients.
+    """
+    args = request.args
+    q = args.get("q")
+    f_type = args.get("type")
+    sort = args.get("sort", default="id", type=str)
+
+    if any([q, f_type]):
+        result = search_airlines(q=q or "", type=f_type, sort=sort)
+        return jsonify(result), 200
+
+    limit = args.get("limit", default=DEFAULT_LIMIT, type=int)
+    offset = args.get("offset", default=0, type=int)
+    result = list_airlines(limit=limit, offset=offset, sort=sort)
+    return jsonify(result), 200
+
+@bp.get("/<int:airline_id>")
+def retrieve(airline_id: int):
+    return jsonify(get_airline(airline_id)), 200
+
+@bp.post("/")
+def create():
+    payload = request.get_json(silent=True)
+    if payload is None:
+        raise InvalidInput("Request body must be JSON")
+    created = create_airline(payload)
+    return jsonify(created), 201, {"Location": url_for("airlines.retrieve", airline_id=created["id"])}
+
+@bp.put("/<int:airline_id>")
+def update(airline_id: int):
+    updates = request.get_json(silent=True) or {}
+    return jsonify(update_airline(airline_id, updates)), 200
+
+@bp.delete("/<int:airline_id>")
+def delete(airline_id: int):
+    delete_airline(airline_id)
+    return ("", 204)

--- a/src/record/airlines/repo.py
+++ b/src/record/airlines/repo.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from src.conf import settings
+from src.conf.errors import NotFound
+from src.record.common.storage import ensure_dir, load_list, save_list
+
+class AirlinesRepo:
+    """
+    Tiny JSON-backed store for airlines.
+    File: airlines.json under DATA_DIR.
+    """
+
+    FILE_NAME = "airlines.json"
+
+    def __init__(self, data_dir: Optional[Path | str] = None, autosave: Optional[bool] = None) -> None:
+        base = Path(os.getenv("DATA_DIR", data_dir or settings.DATA_DIR))
+        ensure_dir(base)
+        self._file_path: Path = base / self.FILE_NAME
+        self._autosave: bool = settings.AUTOSAVE if autosave is None else bool(autosave)
+        self._loaded = False
+        self._rows: list[dict] = []
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self._rows = load_list(self._file_path)
+            self._loaded = True
+
+    def save(self) -> None:
+        self._ensure_loaded()
+        save_list(self._file_path, self._rows)
+
+    def reload(self) -> None:
+        self._rows = load_list(self._file_path)
+        self._loaded = True
+
+    def list_all(self) -> list[dict]:
+        self._ensure_loaded()
+        return list(self._rows)
+
+    def get_by_id(self, airline_id: int) -> dict | None:
+        self._ensure_loaded()
+        for rec in self._rows:
+            if int(rec.get("id", -1)) == int(airline_id):
+                return deepcopy(rec)
+        return None
+
+    def exists(self, airline_id: int) -> bool:
+        return self.get_by_id(airline_id) is not None
+
+    def insert(self, record: Mapping[str, Any]) -> dict:
+        self._ensure_loaded()
+        rec = dict(record)
+        self._rows.append(rec)
+        if self._autosave:
+            self.save()
+        return deepcopy(rec)
+
+    def update(self, airline_id: int, patch: Mapping[str, Any]) -> dict:
+        self._ensure_loaded()
+        for i, rec in enumerate(self._rows):
+            if int(rec.get("id", -1)) == int(airline_id):
+                new_rec = {**rec, **{k: v for k, v in patch.items() if k != "id"}}
+                self._rows[i] = new_rec
+                if self._autosave:
+                    self.save()
+                return deepcopy(new_rec)
+        raise NotFound(f"Airline {airline_id} not found")
+
+    def delete(self, airline_id: int) -> bool:
+        self._ensure_loaded()
+        for i, rec in enumerate(self._rows):
+            if int(rec.get("id", -1)) == int(airline_id):
+                del self._rows[i]
+                if self._autosave:
+                    self.save()
+                return True
+        return False
+
+    @property
+    def file_path(self) -> Path:
+        return self._file_path
+
+
+# Lazy, env-aware singleton
+_repo_singleton: Optional[AirlinesRepo] = None
+_repo_dir: Optional[Path] = None
+
+def get_repo() -> AirlinesRepo:
+    global _repo_singleton, _repo_dir
+    desired = Path(os.getenv("DATA_DIR", settings.DATA_DIR))
+    if _repo_singleton is None or _repo_dir != desired:
+        _repo_singleton = AirlinesRepo(desired)
+        _repo_dir = desired
+    return _repo_singleton
+
+def save_all() -> None:
+    if _repo_singleton is not None:
+        _repo_singleton.save()
+
+# Used by tests to isolate state
+def _reset_singleton_for_tests() -> None:
+    global _repo_singleton, _repo_dir
+    _repo_singleton = None
+    _repo_dir = None

--- a/src/record/airlines/service.py
+++ b/src/record/airlines/service.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from src.conf.enums import AIRLINE_TYPES
+from src.conf.errors import ImmutableID, InvalidInput, NotFound
+from src.record.common.search import filter_by_q
+from src.record.common.validation import (
+    validate_unique_id,
+    required_fields,
+    validate_int_id
+)
+from src.record.airlines.repo import AirlinesRepo, get_repo
+
+# simple normalize helpers
+def _norm(x: Any) -> str:
+    return str(x or "").strip()
+
+def _eq_ci(a: Any, b: Any) -> bool:
+    return _norm(a).lower() == _norm(b).lower()
+
+# fields we search over (case-insensitive)
+_SEARCH_FIELDS = ["id", "company_name", "type"]
+
+# allowed sort keys
+_ALLOWED_SORTS = {"id", "company_name", "type"}
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+
+def _safe_sort_key(key: str):
+    k = key if key in _ALLOWED_SORTS else "id"
+    def _key(rec: Mapping[str, Any]):
+        v = rec.get(k)
+        if k == "id":
+            try:
+                return int(v) if v is not None else 0
+            except Exception:
+                return 0
+        return str(v or "").lower()
+    return _key
+
+def _validate_required(payload: Mapping[str, Any]) -> None:
+    required_fields(payload, ["id", "type", "company_name"])
+
+def _validate_formats(payload: Mapping[str, Any]) -> None:
+    # No-op: we canonicalize `type` with _canonical_airline_type().
+    return
+
+def _canonical_airline_type(value: Any) -> str:
+    """
+    Accepts 'national', 'National', 'low_cost', etc., and returns
+    the canonical value from AIRLINE_TYPES (e.g., 'National', 'Low Cost').
+    """
+    v = _norm(value).replace("_", " ").lower()
+    for opt in AIRLINE_TYPES:
+        if opt.lower() == v:
+            return opt
+    raise InvalidInput(f"Invalid type. Allowed: {sorted(AIRLINE_TYPES)}", {"type": value})
+
+def create_airline(payload: Mapping[str, Any], repo: Optional[AirlinesRepo] = None) -> dict:
+    repo = repo or get_repo()
+    _validate_required(payload)
+    airline_id = validate_int_id(payload.get("id"), field="id")
+    validate_unique_id(repo.list_all(), airline_id, field="id")
+
+    record = dict(payload)
+    record["type"] = _canonical_airline_type(record.get("type"))
+    return repo.insert(record)
+
+def update_airline(airline_id: int, updates: Mapping[str, Any], repo: Optional[AirlinesRepo] = None) -> dict:
+    repo = repo or get_repo()
+    airline_id = validate_int_id(airline_id, field="id")
+    if "id" in updates:
+        body_id = validate_int_id(updates["id"], field="id")
+        if body_id != airline_id:
+            raise ImmutableID("ID in body must match path and cannot change")
+    existing = repo.get_by_id(airline_id)
+    if not existing:
+        raise NotFound(f"Airline {airline_id} not found")
+    
+    patch = dict(updates)
+    if "type" in patch:
+        patch["type"] = _canonical_airline_type(patch["type"])
+    return repo.update(airline_id, patch)
+
+def delete_airline(airline_id: int, repo: Optional[AirlinesRepo] = None) -> None:
+    repo = repo or get_repo()
+    airline_id = validate_int_id(airline_id, field="id")
+    if not repo.delete(airline_id):
+        raise NotFound(f"Airline {airline_id} not found")
+
+def get_airline(airline_id: int, repo: Optional[AirlinesRepo] = None) -> dict:
+    repo = repo or get_repo()
+    airline_id = validate_int_id(airline_id, field="id")
+    rec = repo.get_by_id(airline_id)
+    if not rec:
+        raise NotFound(f"Airline {airline_id} not found")
+    return rec
+
+def list_airlines(repo: Optional[AirlinesRepo] = None, *, limit: int = DEFAULT_LIMIT, offset: int = 0, sort: str = "id") -> dict:
+    """
+    List with pagination (kept like Clients for now).
+    """
+    repo = repo or get_repo()
+    try:
+        limit = max(0, min(int(limit), MAX_LIMIT))
+        offset = max(0, int(offset))
+    except Exception:
+        raise InvalidInput("limit/offset must be integers")
+    sort_key = (_norm(sort).lower() or "id")
+    if sort_key not in _ALLOWED_SORTS:
+        raise InvalidInput(f"Invalid sort key. Allowed: {sorted(_ALLOWED_SORTS)}")
+    items = repo.list_all()
+    items_sorted = sorted(items, key=_safe_sort_key(sort_key))
+    return {
+        "data": items_sorted[offset: offset + limit] if limit > 0 else items_sorted[offset:],
+        "count": len(items_sorted),
+        "limit": limit,
+        "offset": offset,
+        "sort": sort_key,
+    }
+
+def search_airlines(repo: Optional[AirlinesRepo] = None, *, q: str = "", type: str | None = None, sort: str = "id") -> dict:
+    """
+    Search returns ALL matches (no pagination). This is the one change from Clients.
+    """
+    repo = repo or get_repo()
+    sort_key = (_norm(sort).lower() or "id")
+    if sort_key not in _ALLOWED_SORTS:
+        raise InvalidInput(f"Invalid sort key. Allowed: {sorted(_ALLOWED_SORTS)}")
+    items = repo.list_all()
+    items = filter_by_q(items, _SEARCH_FIELDS, q)
+    if _norm(type):
+        items = [r for r in items if _eq_ci(r.get("type"), type)]
+    items_sorted = sorted(items, key=_safe_sort_key(sort_key))
+    return {
+        "data": items_sorted,
+        "count": len(items_sorted),
+        "sort": sort_key,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from flask import Flask
 from src.main import create_app
 import src.record.clients.repo as clients_repo
+import src.record.airlines.repo as airlines_repo
 
 @pytest.fixture(autouse=True)
 def reset_clients_repo(tmp_data_dir):
@@ -18,6 +19,14 @@ def reset_clients_repo(tmp_data_dir):
     # Optional: reset again after test to avoid lingering state
     if hasattr(clients_repo, "_reset_singleton_for_tests"):
         clients_repo._reset_singleton_for_tests()
+
+@pytest.fixture(autouse=True)
+def _reset_airlines_repo(tmp_data_dir):
+    if hasattr(airlines_repo, "_reset_singleton_for_tests"):
+        airlines_repo._reset_singleton_for_tests()
+    yield
+    if hasattr(airlines_repo, "_reset_singleton_for_tests"):
+        airlines_repo._reset_singleton_for_tests()
 
 @pytest.fixture()
 def tmp_data_dir(monkeypatch):
@@ -42,3 +51,4 @@ def app(tmp_data_dir: Path) -> Flask:
 def client(app: Flask):
     """Flask HTTP client for API endpoint tests."""
     return app.test_client()
+

--- a/tests/test_airlines_api.py
+++ b/tests/test_airlines_api.py
@@ -1,0 +1,56 @@
+import pytest
+
+from src.main import create_app
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+def test_create_then_get(client):
+    # create
+    r = client.post("/api/v1/airlines", json={"id": 1, "type": "National", "company_name": "Air One"})
+    assert r.status_code == 201
+    # get
+    r = client.get("/api/v1/airlines/1")
+    assert r.status_code == 200
+    assert r.get_json()["company_name"] == "Air One"
+
+def test_duplicate_and_validation(client):
+    client.post("/api/v1/airlines", json={"id": 1, "type": "National", "company_name": "Air One"})
+    r = client.post("/api/v1/airlines", json={"id": 1, "type": "National", "company_name": "X"})
+    assert r.status_code == 409
+
+    r = client.post("/api/v1/airlines", json={"id": 2, "type": "bad", "company_name": ""})
+    assert r.status_code in (422, 400)
+
+def test_update_and_delete_flow(client):
+    client.post("/api/v1/airlines", json={"id": 5, "type": "Regional", "company_name": "Sky Two"})
+    r = client.put("/api/v1/airlines/5", json={"company_name": "Sky 2"})
+    assert r.status_code == 200
+    assert r.get_json()["company_name"] == "Sky 2"
+
+    r = client.delete("/api/v1/airlines/5")
+    assert r.status_code == 204
+    r = client.get("/api/v1/airlines/5")
+    assert r.status_code == 404
+
+def test_list_and_search(client):
+    client.post("/api/v1/airlines", json={"id": 1, "type": "National", "company_name": "Air One"})
+    client.post("/api/v1/airlines", json={"id": 2, "type": "Regional", "company_name": "Sky Two"})
+    client.post("/api/v1/airlines", json={"id": 3, "type": "National", "company_name": "National Star"})
+
+    # list (keeps pagination)
+    r = client.get("/api/v1/airlines?limit=2&offset=0&sort=id")
+    body = r.get_json()
+    assert r.status_code == 200
+    assert body["count"] == 3 and "limit" in body and len(body["data"]) == 2
+
+    # search (NO pagination): returns all matches, no limit/offset in payload
+    r = client.get("/api/v1/airlines?q=na&type=National&sort=company_name")
+    body = r.get_json()
+    assert r.status_code == 200
+    assert "limit" not in body and "offset" not in body
+    assert body["count"] == 2
+    assert [x["id"] for x in body["data"]] == [1, 3]  # ascending by company_name

--- a/tests/test_airlines_repo.py
+++ b/tests/test_airlines_repo.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from src.record.airlines.repo import AirlinesRepo
+
+def test_insert_get_update_delete_roundtrip(tmp_path: Path):
+    repo = AirlinesRepo(tmp_path, autosave=True)
+
+    # insert
+    a = repo.insert({"id": 1, "type": "national", "company_name": "Air One"})
+    assert a["id"] == 1
+
+    # get
+    got = repo.get_by_id(1)
+    assert got and got["company_name"] == "Air One"
+
+    # update
+    upd = repo.update(1, {"company_name": "Air Uno"})
+    assert upd["company_name"] == "Air Uno"
+
+    # delete
+    assert repo.delete(1) is True
+    assert repo.get_by_id(1) is None
+
+def test_persistence_roundtrip(tmp_path: Path):
+    repo = AirlinesRepo(tmp_path, autosave=True)
+    repo.insert({"id": 2, "type": "regional", "company_name": "Sky Reg"})
+    repo.save()
+
+    repo2 = AirlinesRepo(tmp_path, autosave=False)
+    result = repo2.get_by_id(2)
+    assert result is not None
+    assert result["company_name"] == "Sky Reg"

--- a/tests/test_airlines_service.py
+++ b/tests/test_airlines_service.py
@@ -1,0 +1,64 @@
+import pytest
+
+from src.conf.errors import DuplicateID, ImmutableID, InvalidInput, NotFound
+from src.record.airlines.service import (
+    create_airline,
+    get_airline,
+    update_airline,
+    delete_airline,
+    list_airlines,
+    search_airlines,
+)
+from src.record.airlines.repo import get_repo, _reset_singleton_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _reset_repo(tmp_data_dir):
+    # make sure singleton points at this test's DATA_DIR
+    _reset_singleton_for_tests()
+    yield
+    _reset_singleton_for_tests()
+
+
+def test_create_valid_and_duplicate():
+    repo = get_repo()
+    a1 = create_airline({"id": 1, "type": "National", "company_name": "Air One"}, repo)
+    assert a1["id"] == 1
+
+    with pytest.raises(DuplicateID):
+        create_airline({"id": 1, "type": "National", "company_name": "X"}, repo)
+
+
+def test_missing_id_or_fields():
+    repo = get_repo()
+    with pytest.raises(InvalidInput):
+        create_airline({"type": "National", "company_name": "No ID"}, repo)
+    with pytest.raises(InvalidInput):
+        create_airline({"id": 2, "type": "bad", "company_name": ""}, repo)
+
+
+def test_update_id_is_immutable_and_not_found():
+    repo = get_repo()
+    create_airline({"id": 10, "type": "Charter", "company_name": "CharterCo"}, repo)
+
+    with pytest.raises(ImmutableID):
+        update_airline(10, {"id": 11}, repo)
+
+    delete_airline(10, repo)
+    with pytest.raises(NotFound):
+        get_airline(10, repo)
+
+
+def test_list_and_search_no_pagination_for_search():
+    repo = get_repo()
+    create_airline({"id": 1, "type": "National", "company_name": "Air One"}, repo)
+    create_airline({"id": 2, "type": "Regional", "company_name": "Sky Two"}, repo)
+    create_airline({"id": 3, "type": "National", "company_name": "National Star"}, repo)
+
+    # list with pagination meta
+    lst = list_airlines(repo, limit=2, offset=0, sort="id")
+    assert lst["count"] == 3 and "limit" in lst and len(lst["data"]) == 2
+
+    # search returns ALL matches (no limit/offset in response)
+    res = search_airlines(repo, q="air", sort="company_name")
+    assert res["count"] == 1 and "limit" not in res and res["data"][0]["id"] == 1


### PR DESCRIPTION
Summary
-------
- Airlines vertical slice (repo/service/API).
- Search returns all matches (no pagination).
- Clients: Capitalize type values ('business' -> 'Business').
- Tests grouped by entity.

Testing
-------
- Local: pytest -q (all green).